### PR TITLE
VGI-180 - Fixed BE validation rule to accept BE0 and BE1 prefixes for VAT ID

### DIFF
--- a/view/frontend/templates/checkout/vat-id-format-validation-rule.phtml
+++ b/view/frontend/templates/checkout/vat-id-format-validation-rule.phtml
@@ -9,7 +9,10 @@
         if (hyva && hyva.formValidation) {
             const vatIDPatternsInfo = {
                 'AT': {regex: /^ATU\d{8}$/, format: 'ATU99999999'},                // Austria
-                'BE': {regex: /^BE0\d{9}$/, format: 'BE0999999999'},               // Belgium
+                'BE': {
+                    regex: /^BE[01]\d{9}$/,
+                    format: 'BE0999999999 <?= $escaper->escapeJs(__('or')) ?> BE1999999999'
+                }, // Belgium
                 'BG': {regex: /^BG\d{9,10}$/, format: 'BG999999999 <?= $escaper->escapeJs(__('or')) ?> BG9999999999'}, // Bulgaria
                 'CY': {regex: /^CY\d{8}[A-Z]$/, format: 'CY99999999X'},            // Cyprus
                 'CZ': {regex: /^CZ\d{8,10}$/, format: 'CZ99999999 <?= $escaper->escapeJs(__('or')) ?> CZ9999999999'}, // Czech Republic


### PR DESCRIPTION
As of recent changes, Belgian VAT numbers starting with '1' are now issued
https://en.wikipedia.org/wiki/VAT_identification_number#European_Union_VAT_identification_numbers

## Changelog
### Fixed
- [VGI-180](https://app.clickup.com/t/6651913/VGI-180) - Fixed BE validation rule to accept BE0 and BE1 prefixes for VAT ID